### PR TITLE
Support PHP5.3+ again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 php:
+  - 5.3
+  - 5.4
+  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -8,8 +11,9 @@ env:
   - FEDORA_VERSION="3.7.0"
   - FEDORA_VERSION="3.8.1"
 before_script:
+  - composer install
   - $TRAVIS_BUILD_DIR/tests/scripts/travis_setup.sh
 script:
-  - phpunit -c tests/travis.xml tests/
+  - vendor/bin/phpunit -c tests/travis.xml tests/
 notifications:
   irc: "irc.freenode.org#islandora"

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "require": {
     "php": ">=5.3.0",
     "lib-curl": "*",
-    "lib-xml": "*"
+    "lib-libxml": "*",
+    "phpunit/phpunit": ">=4.8.35|>=5.4.3.,<=5.0"
   }
 }

--- a/tests/NewDatastreamTest.php
+++ b/tests/NewDatastreamTest.php
@@ -9,7 +9,12 @@ require_once 'Cache.php';
 require_once 'TestHelpers.php';
 
 use \PHPUnit\Framework\TestCase;
-use \PHPUnit\Framework\Error;
+use \PHPUnit\Framework\Error\Error;
+
+// XXX: PHPUnit6 moved the location of the Error class.
+if (class_exists('\PHPUnit\Framework\Error\Error', TRUE)) {
+  class_alias('\PHPUnit\Framework\Error\Error', 'PHPUnit_Framework_Error');
+}
 
 class NewDatastreamTest extends TestCase {
 
@@ -36,7 +41,7 @@ class NewDatastreamTest extends TestCase {
   }
 
   /**
-   * @expectedException Error
+   * @expectedException PHPUnit_Framework_Error
    */
   public function testConstructor() {
     $x = new NewFedoraDatastream('foo', 'zap', $this->object, $this->repository);
@@ -54,14 +59,14 @@ class NewDatastreamTest extends TestCase {
   }
 
   /**
-   * @expectedException Error
+   * @expectedException PHPUnit_Framework_Error
    */
   public function testUnsetControlGroup() {
     unset($this->x->controlGroup);
   }
 
   /**
-   * @expectedException Error
+   * @expectedException PHPUnit_Framework_Error
    */
   public function testSetControlGroup() {
     $this->x->controlGroup = 'M';


### PR DESCRIPTION
Let composer do its composer like things and grab the PHPUnit version tailored around its PHP version. PHPUnit back ported its namespacing to older versions such as 4.8.35: https://github.com/sebastianbergmann/phpunit/commit/791b1a67c25af50e230f841ee7a9c6eba507dc87.

Things to note:
PHPUnit6 moved the location of the Error class as opposed to previous versions so we need this gross looking class alias to handle the Exception in the one test: https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/Error/Error.php.

I'll get to the Scholar pull tomorrow to do similar things.

